### PR TITLE
Add support for image position within its bounds

### DIFF
--- a/src/gen-utils.ts
+++ b/src/gen-utils.ts
@@ -33,10 +33,12 @@ export function getSmartParseNumber(
 
     // Number is already converted to something other than inches
     // Assume any number greater than 100 is not inches! Just return it (its EMU already i guess??)
-    if (typeof size === 'number' && size >= 100) return size
+    if (typeof size === 'number' && size >= 100) return Math.round(size)
 
     if (typeof size === 'string' && CALC_EXPR.test(size)) {
-        return calc(size, v => getSmartParseNumber(v, xyDir, layout))
+        return Math.round(
+            calc(size, v => getSmartParseNumber(v, xyDir, layout))
+        )
     }
 
     // Percentage (ex: '50%')


### PR DESCRIPTION
This add two new options `objectAlign` and `objectVAlign` (with top, left, bottom, right, center and middle options where they make sense). This allows to position the image within its box in `cover` or `contain` modes.

![Capture d’écran 2020-02-04 à 10 55 56](https://user-images.githubusercontent.com/263325/73736137-974b6080-4740-11ea-95c9-fe49b5f0834e.png)
 