### PR TITLE
Fix default valign

### DIFF
--- a/src/elements/text.ts
+++ b/src/elements/text.ts
@@ -113,7 +113,7 @@ export default class TextElement implements ElementInterface {
                 valign: opts.valign,
                 wrap: opts.wrap
             },
-            !opts.placeholder
+            !!opts.placeholder
         )
         this.paragraphProperties = new ParagraphProperties({
             bullet: opts.bullet,


### PR DESCRIPTION
Yep, this was this simple - we do not add our defaults if there is a placeholder (not the other way around).