### PR TITLE
Add current date as a new element for masters

### DIFF
--- a/src/core-enums.ts
+++ b/src/core-enums.ts
@@ -134,6 +134,8 @@ export enum MASTER_OBJECTS {
     'line' = 'line',
     'rect' = 'rect',
     'text' = 'text',
+    'slide-number' = 'slide-number',
+    'current-date' = 'current-date',
     'placeholder' = 'placeholder'
 }
 

--- a/src/elements/current-date.ts
+++ b/src/elements/current-date.ts
@@ -1,0 +1,61 @@
+import { getUuid } from '../gen-utils'
+
+import ElementInterface from './element-interface'
+
+import Position from './position'
+import RunProperties from './run-properties'
+
+export default class CurrentDateElement implements ElementInterface {
+    position
+    runProperties
+    fieldId
+    dateFormat?: string
+
+    constructor({ x, y, w, h, dateFormat, ...runOptions }, relations) {
+        this.fieldId = getUuid('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx')
+        this.dateFormat =
+            dateFormat && dateFormat > 0 && dateFormat < 14
+                ? `datetime${dateFormat}`
+                : 'datetime'
+        this.position = new Position({
+            x,
+            y,
+            w: w || 800000,
+            h: h || 300000
+        })
+        this.runProperties = new RunProperties(runOptions, relations)
+    }
+    render(idx, presLayout, placeholder) {
+        return `
+		<p:sp>
+		    <p:nvSpPr>
+			    <p:cNvPr id="${idx + 1}" name="Datetime Placeholder ${idx + 1}"/>
+			    <p:cNvSpPr txBox="1"></p:cNvSpPr>
+			    <p:nvPr userDrawn="1" />
+			</p:nvSpPr>
+
+			<p:spPr>
+			    ${this.position.render(presLayout)}
+			    <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+          <a:extLst><a:ext uri="{C572A759-6A51-4108-AA02-DFA0A04FC94B}">
+            <ma14:wrappingTextBoxFlag 
+             val="0" 
+             xmlns:ma14="http://schemas.microsoft.com/office/mac/drawingml/2011/main"/>
+          </a:ext></a:extLst>
+			</p:spPr>
+
+		    <p:txBody>
+		        <a:bodyPr/>
+		        <a:lstStyle><a:lvl1pPr>
+		            ${this.runProperties.render('a:defRPr')}
+		        </a:lvl1pPr></a:lstStyle>
+                <a:p>
+                    <a:fld id="{${this.fieldId}}" type="${this.dateFormat}">
+                    <a:rPr /><a:t>‹today›</a:t>
+                    </a:fld>
+                    <a:endParaRPr />
+                </a:p>
+            </p:txBody>
+        </p:sp>`
+    }
+}

--- a/src/slideLayouts.ts
+++ b/src/slideLayouts.ts
@@ -15,6 +15,7 @@ import PlaceholderImageElement from './elements/placeholder-image'
 import ImageElement from './elements/image'
 import ChartElement from './elements/chart'
 import SlideNumberElement from './elements/slide-number'
+import CurrentDateElement from './elements/current-date'
 
 type Placeholder = PlaceholderImageElement & PlaceholderTextElement
 
@@ -117,6 +118,20 @@ export class Master {
                     this.data.push(
                         new TextElement(
                             object[key].text,
+                            object[key].options,
+                            this.relations
+                        )
+                    )
+                } else if (MASTER_OBJECTS[key] && key === 'current-date') {
+                    this.data.push(
+                        new CurrentDateElement(
+                            object[key].options,
+                            this.relations
+                        )
+                    )
+                } else if (MASTER_OBJECTS[key] && key === 'slide-number') {
+                    this.data.push(
+                        new SlideNumberElement(
                             object[key].options,
                             this.relations
                         )


### PR DESCRIPTION
Works mostly like the slide-number, only adds a dateFormat option, that for now can take a number between 1 and 13 (and follows [these definitions](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.field?view=openxml-2.8.1))