### PR TITLE
placeholder support for generated fields: sldNum and dt

### DIFF
--- a/src/elements/placeholder.ts
+++ b/src/elements/placeholder.ts
@@ -1,3 +1,4 @@
+import { getUuid } from '../gen-utils'
 import ElementInterface from './element-interface'
 import Position from './position'
 
@@ -9,18 +10,36 @@ export type PlaceholderOptions = {
 export default class Placeholder implements ElementInterface {
     public name: string
     public position: Position
+    public fieldId: string
 
     public placeholderType
     protected placeholderIndex
 
     constructor(name, type = 'body', index) {
         this.name = name
+        this.fieldId = getUuid('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx')
         this.placeholderType = type
         this.placeholderIndex = index
     }
 
     renderPlaceholderInfo() {
         return `<p:ph idx="${this.placeholderIndex}" type="${this.placeholderType}" />`
+    }
+
+    renderFldProps() {
+        // https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_fld_topic_ID0E45SKB.html
+        let type
+        switch (this.placeholderType) {
+            case 'sldNum':
+                type = 'slidenum'
+                break
+            case 'dt':
+                type = 'datetimeFigureOut'
+                break
+        }
+        if (!type) return
+
+        return `id="{${this.fieldId}}" type="${type}"`
     }
 
     public render(idx, presLayout) {

--- a/src/elements/text.ts
+++ b/src/elements/text.ts
@@ -154,6 +154,8 @@ export default class TextElement implements ElementInterface {
     }
 
     render(idx, presLayout, placeholder) {
+        // // https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.field?view=openxml-2.8.1
+        const fld = placeholder ? placeholder.renderFldProps() : null
         return `
     <p:sp>
         <p:nvSpPr>
@@ -182,10 +184,12 @@ export default class TextElement implements ElementInterface {
                 )}
             </a:lstStyle>
             <a:p>
+                ${fld ? `<a:fld ${fld}>` : ''}
                 ${this.fragments
                     .map(fragment => fragment.render(presLayout))
                     .join('</a:p><a:p>')}
                 ${'' /* NOTE: Added 20180101 to address PPT-2007 issues */}
+                ${fld ? `</a:fld>` : ''}
 		        <a:endParaRPr lang="${this.lang || 'en-US'}" dirty="0"/>
             </a:p>
         </p:txBody>


### PR DESCRIPTION
Enables PowerPoint to recognise placeholders with these types

https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_fld_topic_ID0E45SKB.html
https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.field?view=openxml-2.8.1